### PR TITLE
chore: Fix and update base image update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
 
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly

--- a/.github/workflows/update-base-image.yml
+++ b/.github/workflows/update-base-image.yml
@@ -3,6 +3,7 @@ name: Check for aws-cli update
 on:
   schedule:
     - cron: '0 13 * * 2' # 13:00 UTC every Tuesday
+
   workflow_dispatch:
 
 jobs:
@@ -32,22 +33,40 @@ jobs:
     if: needs.check.outputs.needs-update == 'true'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.KINETICCAFE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.KINETICCAFE_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+
       - uses: extractions/setup-just@v2
+
       - run: |
           just update-base-image
-      - uses: peter-evans/create-pull-request@v6.1.0
+
+      - uses: peter-evans/create-pull-request@v7.0.5
+        id: pr
         with:
-          commit-message: ${{ env.UPDATE_TITLE }}
+          token: ${{ steps.generate-token.outputs.token }}
+          sign-commits: true
+          commit-message: |
+            ${{ env.UPDATE_TITLE }}
 
             ${{ env.UPDATE_BODY }}
           branch: update-base-image/${{ env.UPDATE_VERSION }}
           title: ${{ env.UPDATE_TITLE }}
           body: ${{ env.UPDATE_BODY }}
-          draft: true
           labels: |
             automated
           assignees: |
             halostatue
           reviewers: |
             halostatue
+
+      - run: |
+          gh pr merge --rebase --auto ${{ steps.pr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ The versioning for this image tracks the same versioning as AWS CLI.
 
 <!-- automatic-release -->
 
+## 2.17.59 / 2024-09-25
+
+- Automatic update to amazon/aws-cli:2.17.59
+
 ## 2.17.52 / 2024-09-17
 
 - Automatic update to amazon/aws-cli:2.17.52

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG AWS_CLI_VERSION=2.17.52
+ARG AWS_CLI_VERSION=2.17.59
 
 FROM amazon/aws-cli:${AWS_CLI_VERSION}
 

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,4 @@
-AWS_CLI_VERSION := '2.17.52'
+AWS_CLI_VERSION := '2.17.59'
 
 # Build the image
 build:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Manager plugin][] for AWS CLI. If Amazon starts including image versions with
 the session manager plugin included, this image will be discontinued.
 
 These images can be pulled either from Docker Hub
-(`kineticcafe/aws-cli-session-manager:2.17.52`) or GitHub Container Registry
-(`ghcr.io/kineticcafe/aws-cli-session-manager:2.17.52`).
+(`kineticcafe/aws-cli-session-manager:2.17.59`) or GitHub Container Registry
+(`ghcr.io/kineticcafe/aws-cli-session-manager:2.17.59`).
 
 ## `aws-cli-session-manager` script
 
@@ -15,12 +15,12 @@ The `aws-cli-session-manager` script is recommended to be installed in your
 had the native installation on your system, including the use of the AWS command
 completer.
 
-It will pull from `ghcr.io/kineticcafe/aws-cli-session-manager:2.17.52` by
+It will pull from `ghcr.io/kineticcafe/aws-cli-session-manager:2.17.59` by
 default. The version can be overridden by specifying `AWS_CLI_VERSION` and the
 image can be overridden entirely by specifying `IMAGE`:
 
 ```sh
-$ AWS_CLI_VERSION=2.17.52 ./aws-cli-session-manager --version
+$ AWS_CLI_VERSION=2.17.59 ./aws-cli-session-manager --version
 $ IMAGE=kineticcafe/aws-cli-session-manager:latest ./aws-cli-session-manager --version
 ```
 

--- a/aws-cli-session-manager
+++ b/aws-cli-session-manager
@@ -2,7 +2,7 @@
 
 declare engine image mountopt aws_cli_version force_tty read_write
 engine="${ENGINE:-docker}" # for planned compatibility with podman
-aws_cli_version="${AWS_CLI_VERSION:-2.17.52}"
+aws_cli_version="${AWS_CLI_VERSION:-2.17.59}"
 image="${IMAGE:-ghcr.io/kineticcafe/aws-cli-session-manager:${aws_cli_version}}"
 force_tty=false
 read_write=false

--- a/support/version_update.rb
+++ b/support/version_update.rb
@@ -67,7 +67,7 @@ end
 body = <<~EOF_GITHUB_ENV
   UPDATE_VERSION=#{new_version}
   UPDATE_TITLE=Update amazon/aws-cli base image #{release_header}
-  UPDATE_BODY="\n#{history_body}"
+  UPDATE_BODY="#{history_body}"
 EOF_GITHUB_ENV
 
 puts body


### PR DESCRIPTION
A previous change to the output from the support script broke the action; this fixes that and ties to ensure that the commit message will be properly formatted from this point forward.

This also explicitly upgrades to create-pull-request v7 and enables commit signing with a GitHub app, which should permit the actions to be run automatically without requiring modification by a maintainer, allowing this to be merged faster. As such, the `draft` configuration has been removed and a step to enable auto-merge has been added.`